### PR TITLE
한줄외치기가 자동으로 슬라이드 된다

### DIFF
--- a/src/components/FestivalSentence.tsx
+++ b/src/components/FestivalSentence.tsx
@@ -1,62 +1,10 @@
 import styled from 'styled-components';
 
+import MainSentence from './MainSentence';
+
 const FestivalSentenceBox = styled.div`
-    margin-top: 13rem;
-    background-color: #F8F8FA;
-    width: 100%;
-    height: 61px;
-    border-radius: 12px;
-    display:flex;
-    align-items: center;
 `;
 
-const BallonBox = styled.div`
-        display:flex;
-        flex-direction:column;
-        justify-content: center;
-
-        div{
-           color: rgba(147, 147, 147, 1);
-            font-family: SF Pro;
-            font-size: 12px;
-            font-style: normal;
-            font-weight: 510;
-            line-height: 21px; /* 175% */
-            letter-spacing: -0.36px;
-            margin-left:12px;
-            margin-right:10px;
-        }
-
-        img{
-            width: 34px;
-            height: 30.16px;
-            top: 496px;
-            left: 44px;
-            margin-left:16px;
-        }
-`;
-
-const SentenceBox = styled.div`
-        color: #0042B9;
-        font-family: SF Pro;
-        font-size: 16px;
-        font-style: normal;
-        font-weight: 600;
-        line-height: 21px; /* 131.25% */
-        letter-spacing: -0.48px;
-        margin-left:6px;
-
-
-        span{
-            color: #939393;
-            font-family: SF Pro;
-            font-size: 12px;
-            font-style: normal;
-            font-weight: 510;
-            line-height: 100%; /* 12px */
-            letter-spacing: -0.36px;
-        }
-`;
 const WordContainer = styled.div`
         display:flex;
         margin-top:12px;
@@ -79,34 +27,24 @@ const Word = styled.div`
     margin-right:8px;
 `;
 
+
+
 export default function FestivalSentence() {
+    
   return (
     <>
       <FestivalSentenceBox>
-        <BallonBox>
-          <img src="ballon.png" alt="말풍선" />
+        <MainSentence/>
+        <WordContainer>
           {' '}
           {/* 데이터 들어오면 바뀜 */}
-        </BallonBox>
-        <SentenceBox>
-          <span>201902929</span>
-          <br />
-          퇴근길에 이런 글을 보니 기분이 좋네요.
-          {' '}
-          {/* 데이터 들어오면 바뀜 */}
-        </SentenceBox>
+          <Word>아이브</Word>
+          <Word>주점</Word>
+          <Word>양꼬치</Word>
+          <Word>족발</Word>
+          <Word>찜/탕</Word>
+        </WordContainer>
       </FestivalSentenceBox>
-
-      <WordContainer>
-        {' '}
-        {/* 데이터 들어오면 바뀜 */}
-        <Word>아이브</Word>
-        <Word>주점</Word>
-        <Word>양꼬치</Word>
-        <Word>족발</Word>
-        <Word>찜/탕</Word>
-
-      </WordContainer>
     </>
   );
 }

--- a/src/components/MainSentence.tsx
+++ b/src/components/MainSentence.tsx
@@ -1,0 +1,119 @@
+import styled from 'styled-components';
+
+const sentences = [
+  ['201902929', '퇴근길에 이런 글을 보니 기분이 좋네요.', 'ballon.png'],
+  ['202101555', '축제 재밌어요~~', 'ballon.png'],
+  ['202101556', '굿굿', 'ballon.png'],
+  ['202124345', '집가고싶다~', 'ballon.png']
+];
+
+const MainSentenceBox = styled.div`
+        color: #0042B9;
+        font-family: SF Pro;
+        font-size: 16px;
+        font-style: normal;
+        font-weight: 600;
+        line-height: 21px; /* 131.25% */
+        letter-spacing: -0.48px;
+        margin-left:6px;
+
+
+        span{
+            color: #939393;
+            font-family: SF Pro;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 510;
+            line-height: 100%; /* 12px */
+            letter-spacing: -0.36px;
+        }
+
+`;
+
+const BallonBox = styled.div`
+        display:flex;
+        flex-direction:column;
+        justify-content: center;
+
+        div{
+           color: rgba(147, 147, 147, 1);
+            font-family: SF Pro;
+            font-size: 12px;
+            font-style: normal;
+            font-weight: 510;
+            line-height: 21px; /* 175% */
+            letter-spacing: -0.36px;
+            margin-left:12px;
+            margin-right:10px;
+        }
+
+        img{
+            width: 34px;
+            height: 30.16px;
+            top: 496px;
+            left: 44px;
+            margin-left:16px;
+        }
+`;
+
+const SentenceBox = styled.ul`
+    margin-top: 13rem;
+    background-color: #F8F8FA;
+    width: 100%;
+    height: 61px;
+    border-radius: 12px;
+    align-items: center;
+    overflow: hidden;
+
+
+    li > div{
+      display: flex;
+      margin-top: 1rem;
+      margin-bottom: 1rem;
+    }
+
+    li{
+      position: relative;
+      overflow: hidden;
+      animation: slideUp 12s linear infinite;
+    }
+
+    @keyframes slideUp {
+    0%, 14% {
+      top: 0;
+    }
+    28%, 42% {
+      top: -61px;
+    }
+    56%, 70%{
+      top: -122px;
+    }
+    84%, 99% {
+      top: -183px;
+    }
+    100%{
+      top: 0px;
+    }
+  }
+`
+
+export default function MainSentence(){
+    return (
+      <SentenceBox>
+      {sentences.map((sentence, index) => (
+        <li key={index}>
+          <div>
+            <BallonBox>
+              <img src={sentence[2]} alt="말풍선" />
+            </BallonBox>
+            <MainSentenceBox>
+              <span>{sentence[0]}</span>
+              <br />
+              {sentence[1]}
+            </MainSentenceBox>
+          </div>
+        </li>
+      ))}
+    </SentenceBox>
+    );
+  }


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 한줄외치기 부분이 한 문장으로 고정되어있었는데, 여러 문장들을 받아와서 각 문장이 위로 슬라이드 되도록 구현하고자했습니다. 그러나 현재 코드는 문장을 4개 받아오는 것에만 제대로 작동하고, 개수가 늘어나면 코드를 수정해야해서 문장에 개수에 따라 바뀌게 하는 문제는 해결하지 못했습니다. 그리고 문장들이 담긴 배열에서 마지막 문장에서 다시 첫번째 문장으로 넘어갈 때 첫번째 문장으로 스크롤 되듯이 올라가는 게 보이는 문제도 해결하지 못했습니다.

# 어떻게 해결하셨나요? 🔑

* 문장이 담긴 배열에 mapping을 하고, 애니메이션을 주었습니다. slideUp 애니메이션에서 구간에 따라 높이를 설정하여 문장이 머무는 시간과 지나가는 시간을 조절하였습니다.  

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
![한줄외치기슬라이드](https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/105384780/e7b393cf-abbc-448b-80a8-e859634e3820)
