### PR TITLE
한 줄 외치기, 단어들을 좌우로 슬라이드하기

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ const Wrapper = styled.div`
 	flex-direction: column;
 `;
 const Main = styled.div`
+  width: 375px; 
 	display: flex;
 	flex-direction: column;
 	margin: 0 auto;

--- a/src/components/FestivalSentence.tsx
+++ b/src/components/FestivalSentence.tsx
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
 
+import { Swiper, SwiperSlide } from 'swiper/react';
+import 'swiper/swiper-bundle.min.css'
+import 'swiper/swiper.min.css'
+import 'swiper/components/navigation/navigation.min.css'
+import 'swiper/components/pagination/pagination.min.css'
+
+
 const FestivalSentenceBox = styled.div`
     margin-top: 13rem;
     background-color: #F8F8FA;
@@ -79,6 +86,8 @@ const Word = styled.div`
     margin-right:8px;
 `;
 
+const wordList = ['아이브', '주점', '족발', '찜/탕', '양꼬치', '짜장면', "짬뽕", '퇴근', '교수님', '실시간']
+
 export default function FestivalSentence() {
   return (
     <>
@@ -98,14 +107,18 @@ export default function FestivalSentence() {
       </FestivalSentenceBox>
 
       <WordContainer>
-        {' '}
-        {/* 데이터 들어오면 바뀜 */}
-        <Word>아이브</Word>
-        <Word>주점</Word>
-        <Word>양꼬치</Word>
-        <Word>족발</Word>
-        <Word>찜/탕</Word>
-
+        <Swiper
+          slidesPerView={5}
+          allowTouchMove={true}
+          freeMode={true}
+          freeModeMinimumVelocity={0.01}
+        >
+          {wordList.map((word) => (
+            <SwiperSlide>
+              <Word>{word}</Word>
+            </SwiperSlide>
+          ))}
+        </Swiper>
       </WordContainer>
     </>
   );

--- a/src/components/LineupItem.tsx
+++ b/src/components/LineupItem.tsx
@@ -36,7 +36,6 @@ export default function LineupItem({perView, spaceBetween, demoImgList}: LineupI
         speed={300}
         pagination={{ clickable: true }}
         loop={check}
-        hashNavigation={true}
         allowTouchMove={true}
       >
         {demoImgList.map((img, index) => {


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 한 줄 외치기, 단어들을 좌우로 슬라이드하기

# 어떻게 해결하셨나요? 🔑

* 오늘의 라인업과 마찬가지로 Swiper 라이브러리를 사용했습니다. 라인업과 다른 점은 다음과 같습니다. 
  * Width 가 고정된 상태여서 디바이스마다 한 화면에 보여줄 개수를 고려하지 않아도 됩니다.
  *  스와이프를 했을 때, 하나씩 넘기는 형태가 아닌 자연스럽게 미끄러지는 슬라이드 형태입니다.
 
## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!

![한줄외치기단어](https://github.com/kaori-killer/INU-Festival-FE/assets/75800958/fc33a260-13f3-4d09-b0db-f4f6d7e9059d)

* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
