### PR TITLE
Notice page header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import MapPage from './pages/MapPage';
 import ProfilePage from './pages/ProfilePage';
 import GuestBookPage from './pages/GuestBookPage';
 import TimeTablePage from './pages/TitmeTablePage';
+import NoticePage from './pages/NoticePage';
 
 const Container = styled.div`
   margin: 0 auto;
@@ -37,6 +38,7 @@ const routes = [
       { path: '/timetable', element: <TimeTablePage /> },
       { path: '/guestbook', element: <GuestBookPage /> },
       { path: '/profile', element: <ProfilePage /> },
+      { path: '/notices', element: <NoticePage /> },
     ],
   },
 ];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,3 +1,4 @@
+import { NavLink } from 'react-router-dom';
 import styled from 'styled-components';
 
 const Container = styled.div`
@@ -35,6 +36,8 @@ const Title = styled.div`
     }
 `;
 
+
+
 export default function Header() {
   return (
     <Container>
@@ -42,7 +45,11 @@ export default function Header() {
         <img src="logo.png" alt="로고" />
         <span>희희낙락</span>
       </Title>
-      <img src="notification.png" alt="공지사항" />
+      <NavLink to="/notices">
+        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="22" viewBox="0 0 20 22" fill="none">
+          <path d="M20 10.9995C20 8.96371 18.3451 7.29728 16.247 7.14787V2.29157C16.247 1.02571 15.1691 0 13.8387 0H13.7405C13.2463 0 12.7618 0.135661 12.3466 0.3914L4.71438 5.08637H2.40825C1.07793 5.08637 0 6.11208 0 7.37794V13.8072C0 15.073 1.07793 16.0987 2.40825 16.0987H4.71438L12.2984 21.5114C12.7425 21.8286 13.2829 22 13.8387 22C15.1691 22 16.247 20.9743 16.247 19.7084V14.8521C18.346 14.7027 20 13.0363 20 11.0005V10.9995Z" fill="white"/>
+        </svg>
+      </NavLink>
     </Container>
   );
 }

--- a/src/components/Notice/Header.tsx
+++ b/src/components/Notice/Header.tsx
@@ -5,7 +5,7 @@ type HeaderProps = {
 	children: React.ReactNode;
 }
 
-export default function PageHeader({ children }: HeaderProps) {
+export default function Header({ children }: HeaderProps) {
     const HeaderContainer = styled.div`
     width: 100%;
     display: flex;

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,0 +1,41 @@
+import { NavLink } from 'react-router-dom';
+import styled from 'styled-components';
+
+type HeaderProps = {
+	children: React.ReactNode;
+}
+
+export default function PageHeader({ children }: HeaderProps) {
+    const HeaderContainer = styled.div`
+    width: 100%;
+    display: flex;
+    align-items: center;
+    padding-inline: ${(props) => props.theme.sizes.contentPadding};
+    margin-top: .7em;
+    margin-bottom: .7em;
+    padding-block: 1.4em;
+    box-shadow: 0px 0.3rem 0.3rem 0px rgba(0, 0, 0, 0.05);
+    /* padding-bottom: 1rem; */
+  
+  
+    span{
+      margin: 0 auto;
+      font-weight: 700;
+      letter-spacing: -0.04638rem;
+      flex-direction: column;
+      padding-right: 11px;
+    }
+  `;
+
+    return(
+        <HeaderContainer>
+            <NavLink to="/">
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="20" viewBox="0 0 11 20" fill="none">
+                    <path fill-rule="evenodd" clip-rule="evenodd" d="M0.706858 9.19451C0.316334 9.58503 0.316334 10.2182 0.706858 10.6087L9.19426 19.0961C9.58479 19.4866 10.2179 19.4866 10.6085 19.0961C10.999 18.7056 10.999 18.0724 10.6085 17.6819L2.82818 9.90162L10.6085 2.12132C10.999 1.7308 10.999 1.09763 10.6085 0.707107C10.2179 0.316582 9.58479 0.316582 9.19426 0.707107L0.706858 9.19451Z" fill="black"/>
+                </svg>
+            </NavLink>
+            <span>{children}</span>
+        </HeaderContainer>
+    )
+
+}

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -1,5 +1,5 @@
 import { styled } from 'styled-components';
-import PageHeader from '../components/PageHeader';
+import Header from '../components/Notice/Header';
 
 export default function NoticePage() {
   const Wrapper = styled.div`
@@ -9,7 +9,7 @@ export default function NoticePage() {
 
   return (
     <Wrapper>
-      <PageHeader>알림 센터</PageHeader>
+      <Header>알림 센터</Header>
     </Wrapper>
   );
 }

--- a/src/pages/NoticePage.tsx
+++ b/src/pages/NoticePage.tsx
@@ -1,0 +1,15 @@
+import { styled } from 'styled-components';
+import PageHeader from '../components/PageHeader';
+
+export default function NoticePage() {
+  const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+  return (
+    <Wrapper>
+      <PageHeader>알림 센터</PageHeader>
+    </Wrapper>
+  );
+}


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 알림 센터(공지사항) 페이지의 헤더를 만들었다.
* 메인페이지의 알림 센터 아이콘을 바꾸고 연결했다.

* 페이지의 이름만 바뀐 채로 헤더가 재사용되어서 컴포넌트로 분리했는데, 메인의 헤더와는 달라서 헤더의 이름을 어떻게 해야할 지 모르겠다.
* 메인의 헤더와 크기 및 위치는 같게 헤야할 것 같은데 디자인에 비해서 아래 여백이 커보이는 것 같다.


# 어떻게 해결하셨나요? 🔑

* 일단은 메인페이지의 헤더에 위치와 크기를 맞추고, PageHeader로 분리했습니다.

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!

![image](https://github.com/snsdl0905/INU-Festival-FE/assets/105384780/6f2317ae-ec1e-49a3-a421-8097c1a535ee)

![image](https://github.com/snsdl0905/INU-Festival-FE/assets/105384780/7925a1f7-8763-4fbe-a0b4-db810dac3c7e)
