### PR TITLE
[지도 페이지] 버튼을 클릭하면 버튼을 활성화 한다

### DIFF
--- a/src/components/Main/BoothRanking.tsx
+++ b/src/components/Main/BoothRanking.tsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 
 import BoothItem from './BoothItem';
 
-import useFetchBooths from '../../hooks/useFetchBooths';
+import useFetchBoothsRanking from '../../hooks/useFetchBoothsRanking';
 
 const BoothRankingTitle = styled.div`
   width: 100%;
@@ -116,7 +116,7 @@ const BoothHeart = styled.div`
 `;
 
 export default function BoothRanking() {
-  const booths = useFetchBooths();
+  const booths = useFetchBoothsRanking();
   const formatter = new Intl.NumberFormat('en', { notation: 'compact' });
 
   const fetchedBooths = [...booths];

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -27,7 +27,6 @@ const Wrapper = styled.div`
   &:active {
     cursor: grabbing;
   }
-
 `;
 
 const BottemSheetHeader = styled.div`
@@ -43,7 +42,10 @@ const BottemSheetHeader = styled.div`
 
 const BottomSheetContent = styled.div`
     width: 100%;
+    height: 60px;
     display: flex;
+    overflow-x: scroll;
+    margin-top: 5px;
 
     button {
       height: 43px;
@@ -98,7 +100,7 @@ const CategoryFilterContanier = styled.div`
 
 export default function BottomSheet() {
   const { sheet, content } = useBottomSheet();
-  const [isSwipe, setIsSwipe] = useState<booelan>(false);
+  const [isSwipe, setIsSwipe] = useState<boolean>(false);
   const [selectedCategories, setSelectedCategories] = useState<string[]>(['월']);
 
   const categories = ['월', '화', '수', '🍺 주점', '🎡 비주점', '🍕 푸드트럭'];

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -98,10 +98,16 @@ const CategoryFilterContanier = styled.div`
   }
 `;
 
-export default function BottomSheet() {
+type BottomSheetProps = {
+  selectedCategories: string[];
+  setSelectedCategories: (value: string[]) => void;
+}
+export default function BottomSheet({
+  selectedCategories,
+  setSelectedCategories,
+}: BottomSheetProps) {
   const { sheet, content } = useBottomSheet();
   const [isSwipe, setIsSwipe] = useState<boolean>(false);
-  const [selectedCategories, setSelectedCategories] = useState<string[]>(['월']);
 
   const categories = ['월', '화', '수', '🍺 주점', '🎡 비주점', '🍕 푸드트럭'];
 

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -43,7 +43,6 @@ const BottemSheetHeader = styled.div`
 
 const BottomSheetContent = styled.div`
     width: 100%;
-    margin-top: 7px;
     display: flex;
 
     button {
@@ -61,6 +60,19 @@ const BottomSheetContent = styled.div`
       height: 55px;
       cursor: pointer;
     }
+
+    button {
+      background-color: #FFFFFF;
+      border: 1px solid #d4d3d3;
+      color: #7e7d7d;
+    }
+    
+    .clicked {
+        background-color: #EBF2FF;
+        border: 1px solid #e6e5e5;
+        color: #000000;
+        
+    }
 `;
 
 const DayFilterContainer = styled.div`
@@ -70,8 +82,8 @@ const DayFilterContainer = styled.div`
 
   button {
     width: 50px;
-
   }
+
 `;
 
 const CategoryFilterContanier = styled.div`
@@ -86,10 +98,21 @@ const CategoryFilterContanier = styled.div`
 
 export default function BottomSheet() {
   const { sheet, content } = useBottomSheet();
-  const [isSwipe, setIsSwipe] = useState(false);
+  const [isSwipe, setIsSwipe] = useState<booelan>(false);
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(['월']);
+
+  const categories = ['월', '화', '수', '🍺 주점', '🎡 비주점', '🍕 푸드트럭'];
 
   const handleClick = () => {
     setIsSwipe(true);
+  };
+
+  const handleSetFilterCategory = (category: string) => {
+    const filteredCategories = selectedCategories.includes(category)
+      ? selectedCategories.filter((selectedCategory) => selectedCategory !== category)
+      : [...selectedCategories, category];
+
+    setSelectedCategories(filteredCategories);
   };
 
   return (
@@ -100,16 +123,29 @@ export default function BottomSheet() {
     >
       <BottemSheetHeader />
       <BottomSheetContent ref={content}>
-        <DayFilterContainer>
-          <button type="button">월</button>
-          <button type="button">화</button>
-          <button type="button">수</button>
-        </DayFilterContainer>
-        <CategoryFilterContanier>
-          <button type="button">🍺 주점</button>
-          <button type="button">🎡 비주점</button>
-          <button type="button">🍕 푸드트럭</button>
-        </CategoryFilterContanier>
+        {categories.slice(0, 3).map((category) => (
+          <DayFilterContainer key={category}>
+            <button
+              type="button"
+              onClick={() => handleSetFilterCategory(category)}
+              className={selectedCategories.includes(category) ? 'clicked' : ''}
+            >
+              {category}
+            </button>
+          </DayFilterContainer>
+        ))}
+        {categories.splice(3, 6).map((category) => (
+          <CategoryFilterContanier key={category}>
+            <button
+              type="button"
+              onClick={() => handleSetFilterCategory(category)}
+              className={selectedCategories.includes(category) ? 'clicked' : ''}
+            >
+              {category}
+            </button>
+
+          </CategoryFilterContanier>
+        ))}
       </BottomSheetContent>
     </Wrapper>
   );

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,7 +1,9 @@
 import styled from 'styled-components';
 
 import MapLayer from './MapLayer';
-import BottomSheet from './BottomSheet';
+import BottomSheet from './BannerContent';
+
+import useFetchBooths from '../../hooks/useFetchBooths';
 
 const Container = styled.div`
     max-width: 600px;
@@ -12,6 +14,8 @@ const Container = styled.div`
 `;
 
 export default function Map() {
+  const booths = useFetchBooths();
+  console.log(booths);
   return (
     <Container>
       <MapLayer />

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 
+import { useState } from 'react';
 import MapLayer from './MapLayer';
 import BottomSheet from './BannerContent';
 
@@ -13,13 +14,21 @@ const Container = styled.div`
 
 export default function Map() {
   const booths = useFetchBooths();
-  const categories = ['월', '화', '수', '주점', '비주점', '푸드트럭'];
+
+  const [selectedCategories, setSelectedCategories] = useState<string[]>(['월']);
+
   console.log(booths);
+  // const filteredBooths = booths.filter((booth) =>
+  //   booth.boothDays
+  // );  console.log(selectedCategories);
 
   return (
     <Container>
       <MapLayer />
-      <BottomSheet />
+      <BottomSheet
+        selectedCategories={selectedCategories}
+        setSelectedCategories={setSelectedCategories}
+      />
     </Container>
   );
 }

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -8,14 +8,14 @@ import useFetchBooths from '../../hooks/useFetchBooths';
 const Container = styled.div`
     max-width: 600px;
     width: 100%;
-    height: 100%;
-    overflow: hidden;
     cursor: grab;
 `;
 
 export default function Map() {
   const booths = useFetchBooths();
+  const categories = ['월', '화', '수', '주점', '비주점', '푸드트럭'];
   console.log(booths);
+
   return (
     <Container>
       <MapLayer />

--- a/src/components/Map/MapLayer.tsx
+++ b/src/components/Map/MapLayer.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
     max-width: 600px;
     width: 100%;
     position: absolute;
-    height: 49em;
+    height: 42em;
 `;
 
 export default function MapLayer() {

--- a/src/components/Map/MapLayer.tsx
+++ b/src/components/Map/MapLayer.tsx
@@ -8,7 +8,7 @@ const Container = styled.div`
     max-width: 600px;
     width: 100%;
     position: absolute;
-    height: 42em;
+    height: 100em;
 `;
 
 export default function MapLayer() {

--- a/src/components/MapDetail/DetailedMapPage.tsx
+++ b/src/components/MapDetail/DetailedMapPage.tsx
@@ -8,7 +8,7 @@ import Header from '../Notice/Header';
 import BoothInstruction from './BoothInstruction';
 import BoothComment from './BoothComment';
 import InfoWithIcon from './InfoWithIcon';
-import useFetchBooths from '../../hooks/useFetchBooths';
+import useFetchBoothsRanking from '../../hooks/useFetchBoothsRanking';
 
 const ImageBox = styled.div`
 
@@ -111,7 +111,7 @@ const MapImageBox = styled.div`
 export default function DetailedMapPage() {
   const { id } = useParams();
   const [showinstruction, setShowInstruction] = useState(true);
-  const booths = useFetchBooths();
+  const booths = useFetchBoothsRanking();
   const SelectedBooth = booths.find((booth) => booth.id === id);
   const imgArray: string[] = ['/BOL.jpeg', '/BOL2.jpeg', '/DAMONS.png'];
 

--- a/src/components/Profile/HelpSection.tsx
+++ b/src/components/Profile/HelpSection.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 
-const HelpWrapper = styled.li`
+const HelpWrapper = styled.ul`
 width: 100%;
 padding-top:20px;
 list-style:none;

--- a/src/hooks/useBottomSheet.ts
+++ b/src/hooks/useBottomSheet.ts
@@ -42,7 +42,6 @@ export function useBottomSheet() {
       }
 
       // 바텀시트가 올라와있는 상태가 아닐 때는 컨텐츠 영역을 터치해도 바텀시트를 움직이는 것이 자연스럽습니다.
-      console.log(sheet.current);
       if (sheet.current?.getBoundingClientRect().y !== MIN_Y) {
         return true;
       }

--- a/src/hooks/useCheckScreenWidth.ts
+++ b/src/hooks/useCheckScreenWidth.ts
@@ -14,10 +14,8 @@ export default function useCheckScreenWidth(
     });
     if (window.innerWidth <= 550) {
       setPerView(defaultPerview - 1.3);
-    } else if (window.innerWidth <= 1200) {
-      setPerView(defaultPerview - 0.3);
     } else {
-      setPerView(defaultPerview);
+      setPerView(defaultPerview - 0.3);
     }
   };
 

--- a/src/hooks/useFetchBooths.ts
+++ b/src/hooks/useFetchBooths.ts
@@ -1,7 +1,7 @@
 import { useFetch } from 'usehooks-ts';
 import Booth from '../types/Booth';
 
-const url = `${process.env.REACT_APP_URL}/booths/all`;
+const url = `${process.env.REACT_APP_URL}/booth/all`;
 
 type Booths = {
     booths: Booth[];

--- a/src/hooks/useFetchBoothsRanking.ts
+++ b/src/hooks/useFetchBoothsRanking.ts
@@ -1,13 +1,14 @@
 import { useFetch } from 'usehooks-ts';
+
 import Booth from '../types/Booth';
 
-const url = `${process.env.REACT_APP_URL}/booths/all`;
+const url = `${process.env.REACT_APP_URL}/booths/ranking`;
 
 type Booths = {
     booths: Booth[];
 }
 
-export default function useFetchBooths() {
+export default function useFetchBoothsRanking() {
   const { data } = useFetch<Booths>(url);
   if (!data) {
     return [];

--- a/src/styles/GlobalStyle.ts
+++ b/src/styles/GlobalStyle.ts
@@ -19,6 +19,13 @@ const GlobalStyle = createGlobalStyle`
     *::before,
     *::after {
         box-sizing: inherit;
+        
+        -ms-overflow-style: none;  /* IE and Edge */
+        scrollbar-width: none; /* Firefox */
+    }
+
+    *::-webkit-scrollbar {
+      display: none; /* Chrome, Safari, Opera */
     }
 
     :lang(ko) {

--- a/src/types/Booth.ts
+++ b/src/types/Booth.ts
@@ -8,7 +8,6 @@ interface Booth {
     description: string;
     liked: number;
     img: string;
-    comment: number;
     boothDays: BoothDay[];
   }
 

--- a/src/utils/CreateKakaoMap.ts
+++ b/src/utils/CreateKakaoMap.ts
@@ -24,7 +24,7 @@ export default function Kakao() {
     mapTypeId: kakao.maps.MapTypeId.PLAN,
     $scale: false,
     // 지도의 중심 좌표 (x, y)
-    center: new kakao.maps.Coords(750, -700),
+    center: new kakao.maps.Coords(750, -1000),
     level: 0,
   });
   const center = map.getCenter();


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 1) [지도 페이지] 버튼을 클릭하면 버튼을 활성화 해야 한다.
* 2) [지도 페이지] 화면 사이즈에서 버튼이 나가면 좌우로 스크롤이 가능해야 한다.

# 어떻게 해결하셨나요? 🔑
* 1) 선택된 필터를 모아놓은 배열(selectedCategories) 을 만들었습니다. 클릭했을 때 selectedCategories에 클릭한 필터가 들어이으면 그 필터는 selectedCategories에서 뺍니다. 반대로 배열에 클릭한 필터가 없으면 selectedCategories에 추가합니다. 이렇게 해서 selectedCategories에 필터가 들어있는지 없는지 여부로 CSS를 바꿀 수 있게 했습니다.
* 2) overflow-x: scroll로 좌우로 스크롤이 가능하게 했습니다. (스와이프 라이브러리 안 쓰고 쉽게 좌우로 스크롤이 가능하게 할 수 있었습니다.)

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 1) 필터의 On/Off가 잘 되는 지
* 2) 모바일 화면에서 좌우로 스크롤이 잘 되는 지

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
  * 1) ![pr1](https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/75800958/ebbe1c2e-f619-48d9-9b15-6245fc5543a8)
   * 2) ![pr2](https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/75800958/e7afc0cb-52b4-476b-93dd-cfd3cf501a04)

* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
