### PR TITLE
지도 페이지의 필터 부분과 프로필 페이지의 지원 부분의 버튼이 모바일에서 파란색으로 보여지는 부분 수정

### DIFF
--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -64,6 +64,7 @@ const BottomSheetFilter = styled.div`
     border-bottom: 1px dashed #CEDCEA;
 
     button {
+      color: #000;
       height: 43px;
       border: 0px;
       border-radius: 999px;

--- a/src/components/Profile/HelpSection.tsx
+++ b/src/components/Profile/HelpSection.tsx
@@ -35,6 +35,7 @@ margin-right: 12px;
 `;
 
 const Helplink = styled.button`
+  color: #000;
   font-family: SUIT, sans-serif;
   font-size: 16px;
   font-style: normal;


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 지도 페이지의 필터 부분과 프로필 페이지의 지원 부분의 버튼이 모바일에서 파란색으로 보여진다.

# 어떻게 해결하셨나요? 🔑

* 폰트 색상을 #000으로 잡았다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

*

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
