### PR TITLE
프로필 페이지의 지원 목록의 글자 크기가 아이폰에서 잘리는 버그 발생, 글자를 감싸고 있는 태그의 height를 늘림

### DIFF
--- a/src/components/Profile/HelpSection.tsx
+++ b/src/components/Profile/HelpSection.tsx
@@ -20,9 +20,9 @@ const HelpTitle = styled.div`
 
 const HelpElement = styled.li`
 width: 100%;
-height: 19px;
+height: 23px;
 flex-shrink: 0;
-margin-bottom:32px;
+margin-bottom:27px;
 display:flex;
 cursor: pointer;
 `;


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 프로필 페이지의 지원 목록의 글자 크기가 아이폰에서 잘리는 버그가 발생했다.

# 어떻게 해결하셨나요? 🔑

*  글자를 감싸고 있는 태그의 height를 늘렸다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

*

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
