### PR TITLE
부스 디테일에서 헤더 부분에 의해 이미지가 가려지는 버그 해결

### DIFF
--- a/src/components/MapDetail/DetailedMapPage.tsx
+++ b/src/components/MapDetail/DetailedMapPage.tsx
@@ -121,6 +121,7 @@ const MapImageContainer = styled.div<{translateImg: string}>`
   height: 90vw;
   background-color: #D1D9F5;
   transform: translateX(${(props) => props.translateImg});
+  margin-top: 52px;
   `;
 
 const ImageBox = styled.div`


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 부스 디테일에서 헤더 부분에 의해 이미지가 가려지는 버그가 있었습니다.

# 어떻게 해결하셨나요? 🔑

* 헤더 높이만큼 이미지를 내렸습니다. 그래서 헤더와 이미지가 겹치지 않게 했습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

*

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
