### PR TITLE
모든 기기에서 이미지 슬라이드가 끌까지 되게 합니다 (메인 페이지 라인업, 타임테이블, 방명록)

### DIFF
--- a/src/components/Main/LineUp.tsx
+++ b/src/components/Main/LineUp.tsx
@@ -45,6 +45,7 @@ export default function LineUp({
       speed={300}
       pagination={{ clickable: true }}
       allowTouchMove
+      slidesOffsetAfter={50}
     >
       {data === undefined
         ? (

--- a/src/components/TimeTable/Lineups.tsx
+++ b/src/components/TimeTable/Lineups.tsx
@@ -52,7 +52,7 @@ export default function Lineups({ lineups }: LineupsProps) {
         speed={300}
         pagination={{ clickable: true }}
         allowTouchMove
-        slidesOffsetAfter={90}
+        slidesOffsetAfter={100}
 
       >
         {lineups.map((lineup) => (

--- a/src/components/TimeTable/Lineups.tsx
+++ b/src/components/TimeTable/Lineups.tsx
@@ -52,7 +52,7 @@ export default function Lineups({ lineups }: LineupsProps) {
         speed={300}
         pagination={{ clickable: true }}
         allowTouchMove
-        slidesOffsetAfter={100}
+        slidesOffsetAfter={110}
 
       >
         {lineups.map((lineup) => (


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 아이폰 SE 같은 작은 기기에서 이미지가 끝까지 슬라이드가 되지 않았습니다.

# 어떻게 해결하셨나요? 🔑

* 이미지가 끝까지 슬라이드 되도록 slidesOffsetAfter를 추가했습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 여러 기기에서 이미지가 끝까지 슬라이드 되는지, 빠진 부분은 없는지 확인 부탁드립니다~!

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
