### PR TITLE
지도 페이지에서 분류 부분의 필터만 슬라이딩이 가능하도록 수정

### DIFF
--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -1,8 +1,5 @@
-// import { useState } from 'react';
-
 import { styled } from 'styled-components';
 
-// import { useBottomSheet } from '../../hooks/useBottomSheet';
 import BoothList from './BoothList';
 import Booth from '../../types/Booth';
 import useFetchCategories from '../../hooks/useFetchCategories';

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -52,7 +52,16 @@ const BottomSheetFilter = styled.div`
     margin-bottom: 5px;
     padding: 10px 0;
     border-bottom: 1px dashed #CEDCEA;
-    overflow: scroll;
+
+    p{
+      color: #969FA9;
+      font-size: 13px;
+      font-style: normal;
+      font-weight: 400;
+      line-height: 21px;
+      letter-spacing: -0.52px;
+      padding-right: 10px;
+    }
 
     button {
       color: #000;
@@ -106,16 +115,15 @@ const FilterContainer = styled.div`
   display: flex;
   align-items: center;
   width: max-content;
-  
-  p{
-    color: #969FA9;
-    font-size: 13px;
-    font-style: normal;
-    font-weight: 400;
-    line-height: 21px;
-    letter-spacing: -0.52px;
-    padding-right: 10px;
-  }
+`;
+
+const Hello = styled.div`
+    width: 100%;
+    overflow: scroll;
+`;
+
+const Container = styled.div`
+  display: flex;
 `;
 
 type BottomSheetProps = {
@@ -149,34 +157,42 @@ export default function BottomSheet({
       <BottomSheetHeader />
       <BottomSheetContent>
         <BottomSheetFilter>
-          <FilterContainer>
+          <Container>
             <p>요일</p>
-            {days && days.map((category: string) => (
-              <DayFilterContainer key={category}>
-                <button
-                  type="button"
-                  onClick={() => handleSetFilterDay(category)}
-                  className={selectedDay === category ? 'clickedDay' : ''}
-                >
-                  {category}
-                </button>
-              </DayFilterContainer>
-            ))}
-          </FilterContainer>
-          <FilterContainer>
+            <Hello>
+              <FilterContainer>
+                {days && days.map((category: string) => (
+                  <DayFilterContainer key={category}>
+                    <button
+                      type="button"
+                      onClick={() => handleSetFilterDay(category)}
+                      className={selectedDay === category ? 'clickedDay' : ''}
+                    >
+                      {category}
+                    </button>
+                  </DayFilterContainer>
+                ))}
+              </FilterContainer>
+            </Hello>
+          </Container>
+          <Container>
             <p>분류</p>
-            {filters && filters.map((category: string) => (
-              <CategoryFilterContanier key={category}>
-                <button
-                  type="button"
-                  onClick={() => handleSetFilterCategory(category)}
-                  className={selectedCategory === category ? 'clickedCategory' : ''}
-                >
-                  {category}
-                </button>
-              </CategoryFilterContanier>
-            ))}
-          </FilterContainer>
+            <Hello>
+              <FilterContainer>
+                {filters && filters.map((category: string) => (
+                  <CategoryFilterContanier key={category}>
+                    <button
+                      type="button"
+                      onClick={() => handleSetFilterCategory(category)}
+                      className={selectedCategory === category ? 'clickedCategory' : ''}
+                    >
+                      {category}
+                    </button>
+                  </CategoryFilterContanier>
+                ))}
+              </FilterContainer>
+            </Hello>
+          </Container>
         </BottomSheetFilter>
         <BoothList
           booths={booths}

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -49,7 +49,6 @@ const BottomSheetHeader = styled.div`
 const BottomSheetFilter = styled.div`
     width: 100%;
     margin-top: 5px;
-    margin-bottom: 5px;
     padding: 10px 0;
     border-bottom: 1px dashed #CEDCEA;
 
@@ -61,6 +60,7 @@ const BottomSheetFilter = styled.div`
       line-height: 21px;
       letter-spacing: -0.52px;
       padding-right: 10px;
+      width: 45px;
     }
 
     button {
@@ -89,9 +89,6 @@ const BottomSheetFilter = styled.div`
       background-color: #EBF2FF;
     }
 
-    :first-child{
-    margin-bottom: 5px;
-  }
 `;
 
 const DayFilterContainer = styled.div`
@@ -117,13 +114,15 @@ const FilterContainer = styled.div`
   width: max-content;
 `;
 
-const Hello = styled.div`
+const DataFilterContainer = styled.div`
     width: 100%;
     overflow: scroll;
 `;
 
 const Container = styled.div`
   display: flex;
+  align-items: center;
+  margin-bottom: 10px;
 `;
 
 type BottomSheetProps = {
@@ -159,7 +158,7 @@ export default function BottomSheet({
         <BottomSheetFilter>
           <Container>
             <p>요일</p>
-            <Hello>
+            <DataFilterContainer>
               <FilterContainer>
                 {days && days.map((category: string) => (
                   <DayFilterContainer key={category}>
@@ -173,11 +172,11 @@ export default function BottomSheet({
                   </DayFilterContainer>
                 ))}
               </FilterContainer>
-            </Hello>
+            </DataFilterContainer>
           </Container>
           <Container>
             <p>분류</p>
-            <Hello>
+            <DataFilterContainer>
               <FilterContainer>
                 {filters && filters.map((category: string) => (
                   <CategoryFilterContanier key={category}>
@@ -191,7 +190,7 @@ export default function BottomSheet({
                   </CategoryFilterContanier>
                 ))}
               </FilterContainer>
-            </Hello>
+            </DataFilterContainer>
           </Container>
         </BottomSheetFilter>
         <BoothList

--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -100,7 +100,7 @@ const DayFilterContainer = styled.div`
 
 `;
 
-const CategoryFilterContanier = styled.div`
+const CategoryFilterContainer = styled.div`
   display: flex;
 
   button {
@@ -179,7 +179,7 @@ export default function BottomSheet({
             <DataFilterContainer>
               <FilterContainer>
                 {filters && filters.map((category: string) => (
-                  <CategoryFilterContanier key={category}>
+                  <CategoryFilterContainer key={category}>
                     <button
                       type="button"
                       onClick={() => handleSetFilterCategory(category)}
@@ -187,7 +187,7 @@ export default function BottomSheet({
                     >
                       {category}
                     </button>
-                  </CategoryFilterContanier>
+                  </CategoryFilterContainer>
                 ))}
               </FilterContainer>
             </DataFilterContainer>

--- a/src/components/Map/MapLayer.tsx
+++ b/src/components/Map/MapLayer.tsx
@@ -73,7 +73,6 @@ export default function MapLayer({
         marker.setMap(null);
         marker.setMap(kakaoMap);
         setMarkers((prevMarkers) => [...prevMarkers, marker]);
-        console.log(booth.c);
         if (booth.category === '푸드트럭' || booth.category === '플리마켓') return;
 
         kakao.maps.event.addListener(marker, 'click', () => {
@@ -96,8 +95,6 @@ export default function MapLayer({
     resetMarkers();
 
     const booths: Booth[] = selectedBooth || filteredBooths;
-
-    console.log(booths);
 
     booths.forEach((booth) => {
       createMarkers(booth);

--- a/src/hooks/useFetchBoothComment.ts
+++ b/src/hooks/useFetchBoothComment.ts
@@ -10,7 +10,6 @@ export default function useFetchBoothComment(id: string) {
   const url = `${process.env.REACT_APP_URL}/booth/${id}/comment`;
 
   const { data } = useFetch<BoothCommentType>(url);
-  console.log(data);
 
   if (!data) {
     return [];

--- a/src/utils/CreateKakaoMap.ts
+++ b/src/utils/CreateKakaoMap.ts
@@ -27,35 +27,5 @@ export default function Kakao() {
     center: new kakao.maps.Coords(750, -400),
     level: 0,
   });
-  // const center = map.getCenter();
-  // const marker = new kakao.maps.Marker({
-  //   position: center,
-  // });
-  // marker.setMap(map);
-
-  // // 커스텀 오버레이에 표시할 내용입니다
-  // // HTML 문자열 또는 Dom Element 입니다
-  // const content = '<div class ="label"><span class="left"></span><button class="center">안녕</button><span class="right"></span></div>';
-
-  // // 커스텀 오버레이가 표시될 위치입니다
-  // const position = new kakao.maps.Coords(700, -700);
-
-  // // 커스텀 오버레이를 생성합니다
-  // const customOverlay = new kakao.maps.CustomOverlay({
-  //   position,
-  //   content,
-  // });
-
-  // // console.log(customOverlay);
-
-  // // 커스텀 오버레이를 지도에 표시합니다
-  // customOverlay.setMap(map);
-
-  // const infowindow = new kakao.maps.InfoWindow({
-  //   content: '커스텀 타일셋?',
-  // });
-  // infowindow.open(map, marker);
   return map;
 }
-
-// export { kakao };


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 화면에 보여줄 수 있는 버튼의 개수보다 가지고 있는 버튼의 개수가 많아지면 슬라이딩이 가능한데, 기존에는 필터 부분 전체가 슬라이딩 되었습니다.

# 어떻게 해결하셨나요? 🔑

* 현재는 지도 페이지에서 분류 부분의 필터만 슬라이딩이 가능하도록 수정했습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* overflow를 주는 위치를 분류 부분으로 한정지엇습니다.

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
