### PR TITLE
방명록에서 input의 font-size를 변경하여 아이폰에서 확대되는 것을 막음

### DIFF
--- a/src/components/GuestBook/GuestBook.tsx
+++ b/src/components/GuestBook/GuestBook.tsx
@@ -91,7 +91,7 @@ const TextBox = styled.div<{ $isMaximum: boolean }>`
     border: none;
     color: #0042B9;
     font-family: SUIT, sans-serif;
-    font-size: 17px;
+    font-size: 18px;
     font-style: normal;
     font-weight: 800;
     line-height: 21px;

--- a/src/components/GuestBook/GuestBook.tsx
+++ b/src/components/GuestBook/GuestBook.tsx
@@ -91,7 +91,7 @@ const TextBox = styled.div<{ $isMaximum: boolean }>`
     border: none;
     color: #0042B9;
     font-family: SUIT, sans-serif;
-    font-size: 15px;
+    font-size: 17px;
     font-style: normal;
     font-weight: 800;
     line-height: 21px;


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* input의 font-size가 16px 미만이면 아이폰에서 확대가 돼서 17px로 변경하였습니다.

# 어떻게 해결하셨나요? 🔑

* [iOS <input> focus 시 자동 zoom-in 막기](https://devsoyoung.github.io/posts/ios-input-focus-zoom/)

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

*

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
