### PR TITLE
공유하기 버튼을 눌렀을 때 나오는 토스트 박스의 배경색과 radius 추가

### DIFF
--- a/src/components/GuestBook/GuestBook.tsx
+++ b/src/components/GuestBook/GuestBook.tsx
@@ -91,7 +91,7 @@ const TextBox = styled.div<{ $isMaximum: boolean }>`
     border: none;
     color: #0042B9;
     font-family: SUIT, sans-serif;
-    font-size: 15px;
+    font-size: 17px;
     font-style: normal;
     font-weight: 800;
     line-height: 21px;

--- a/src/components/Profile/Toast.tsx
+++ b/src/components/Profile/Toast.tsx
@@ -12,10 +12,13 @@ const ToastBox = styled.div`
     position: fixed;
     bottom: 120px;
     display: flex;
+    background-color: #e8ebf0;
+    border-radius: 15px;
+    padding: 10px;
 
     p{
       margin: 0 auto;
-      color: #a3afbc;
+      color: #1d1d1d;
       padding-right: 16px;
     }
 `;

--- a/src/components/Profile/Toast.tsx
+++ b/src/components/Profile/Toast.tsx
@@ -12,7 +12,7 @@ const ToastBox = styled.div`
     position: fixed;
     bottom: 120px;
     display: flex;
-    background-color: #e8ebf0;
+    background-color: #fafcff; opacity : 0.9;
     border-radius: 15px;
     padding: 10px;
 


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 공유하기 버튼을 눌렀을 때 나오는 토스트 박스가 배경색이 없어서 부스 소개와 겹쳐 보였음.

# 어떻게 해결하셨나요? 🔑

* 공유하기 버튼을 눌렀을 때 나오는 토스트 박스의 배경색과 radius 추가해서 겹쳐 보이지 않도록 함.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

둘 다 잘 보이는지 확인 부탁드립니다!

* 부스 상세보기에서 공유하기
* 프로필 페이지에서 공유하기

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
