### PR TITLE
부스 리스트에서 부스의 내용이 길어질 때, 해당 부스를 좌우로 슬라이딩 할 수 있도록 함

### DIFF
--- a/src/components/Map/BoothList.tsx
+++ b/src/components/Map/BoothList.tsx
@@ -21,6 +21,7 @@ const PreButton = styled.div`
 
 const BoothContainer = styled.div`
     flex: 1;
+    overflow-x: scroll;
     display: flex;
     padding: 10px;
     width: 100%;


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 부스 리스트에서 부스의 내용이 길어질 때, 부스 내용을 보려고 슬라이딩하면 전체적으로 슬라이딩 되었습니다.

# 어떻게 해결하셨나요? 🔑

* 부스 리스트에서 부스의 내용이 길어질 때, 부스 내용을 보려고 슬라이딩하면 해당 부스를 좌우로 슬라이딩 할 수 있도록 했습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 잘 적용되었는지 확인 부탁드립니다~!

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
