### PR TITLE
부스 리스트 페이지에 적용한 필터 내용을 기억하게 하여, 다른 페이지를 방문했다가 부스 리스트 페이지로 돌아와도 필터가 이전과 동일하게 함

### DIFF
--- a/src/components/Map/BannerContent.tsx
+++ b/src/components/Map/BannerContent.tsx
@@ -144,10 +144,12 @@ export default function BottomSheet({
   const { days, filters } = categories;
 
   const handleSetFilterDay = (category: string) => {
+    localStorage.setItem('day', category);
     setSelectedDay(category);
   };
 
   const handleSetFilterCategory = (category: string) => {
+    localStorage.setItem('category', category);
     setSelectedCategory(category);
   };
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -12,9 +12,14 @@ const Container = styled.div`
     cursor: grab;
 `;
 
+const WEEKDAY = ['일', '월', '화', '수', '목', '금', '토'];
+
 export default function Map() {
+  const now = new Date();
+  const month = now.getDay();
+  const day = (WEEKDAY[month] === '화' || WEEKDAY[month] === '수' || WEEKDAY[month] === '목') ? WEEKDAY[month] : '화';
   const booths = useFetchBooths();
-  const [selectedDay, setSelectedDay] = useState<string>(localStorage.getItem('day') || '화');
+  const [selectedDay, setSelectedDay] = useState<string>(localStorage.getItem('day') || day);
   const [selectedCategory, setSelectedCategory] = useState<string>(localStorage.getItem('category') || '비주점');
   const [selectedBooth, setSelectedBooth] = useState<Booth[] | null>(null);
 

--- a/src/components/Map/Map.tsx
+++ b/src/components/Map/Map.tsx
@@ -14,8 +14,8 @@ const Container = styled.div`
 
 export default function Map() {
   const booths = useFetchBooths();
-  const [selectedDay, setSelectedDay] = useState<string>('수');
-  const [selectedCategory, setSelectedCategory] = useState<string>('주점');
+  const [selectedDay, setSelectedDay] = useState<string>(localStorage.getItem('day') || '화');
+  const [selectedCategory, setSelectedCategory] = useState<string>(localStorage.getItem('category') || '비주점');
   const [selectedBooth, setSelectedBooth] = useState<Booth[] | null>(null);
 
   const filtered = booths.filter((booth) => {


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 부스 리스트 페이지에서 필터를 적용하고, 다른 페이지를 방문했다가 돌아오면 필터가 초깃값으로 돌아가게 되었다.
* 필터의 요일 초깃값은 무조건 '화요일'이 기본 값이었다.

# 어떻게 해결하셨나요? 🔑

* 부스 리스트 페이지에 적용한 필터 내용을 기억하게 하여, 다른 페이지를 방문했다가 부스 리스트 페이지로 돌아와도 필터가 이전과 동일하게 함.
* 필터의 요일 초깃값은 오늘의 요일로 변경했다. 만약에 오늘의 요일이 필터에 리스트에 없다면, '화요일'이 기본 값이된다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 다른 페이지에 갔다와도 필터가 제대로 유지되는지 확인 부탁드립니다.
* 필터의 초깃값이 오늘의 요일과 동일한지 확인 부탁드립니다. 만약 리스트에 오늘의 요일이 없으면 화요일로 적용되는지 확인부탁드립니다.

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
