### PR TITLE
배경이미지가 로드되기 전에 CSS가 먼저 적용돼서 배경이 날아갈 경우, 기본 배경색이 보여진다

### DIFF
--- a/src/components/BlurContainer.ts
+++ b/src/components/BlurContainer.ts
@@ -20,7 +20,7 @@ const BlurContainer = styled.div`
     bottom: 0px;
     z-index: -1;
     background-size: cover;
-    background-color: #F5BCC9;
+    background-color: #FEC0CA;
     background-image: url("LineupDefault.jpeg");
   }
 `;

--- a/src/components/BlurContainer.ts
+++ b/src/components/BlurContainer.ts
@@ -9,6 +9,7 @@ const BlurContainer = styled.div`
   border-radius: 0px 0px 12px 12px;
   overflow: hidden;
 
+
   ::before {  
     position: absolute;
     content: "";
@@ -19,7 +20,8 @@ const BlurContainer = styled.div`
     bottom: 0px;
     z-index: -1;
     background-size: cover;
-    background-image: url("LineupDefault.jpeg")
+    background-color: #F5BCC9;
+    background-image: url("LineupDefault.jpeg");
   }
 `;
 

--- a/src/components/Main/Header.tsx
+++ b/src/components/Main/Header.tsx
@@ -4,7 +4,6 @@ import styled from 'styled-components';
 
 const Container = styled.div`
   max-width: 600px;
-  /* height: 69px; */
   padding: 11px 0;
   display: flex;
   justify-content: space-between;

--- a/src/components/Main/LineUp.tsx
+++ b/src/components/Main/LineUp.tsx
@@ -4,7 +4,6 @@ import { Swiper, SwiperSlide } from 'swiper/react';
 
 import useFetchPerforms from '../../hooks/useFetchPerforms';
 
-import SkeletonFestivalLineupItem from '../Loading/SkeletonFestivalLineupItem';
 import Skeleton from '../Loading/Skeleton';
 
 const Container = styled.div`


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 메인 페이지에서 라인업 뒤, 타임테이블 페이지에서 라인업 뒤
  * 배경이미지가 로드되기 전에 CSS가 먼저 적용되면, 배경이 날아간다. 그래서 배경이 안 나왔다.

# 어떻게 해결하셨나요? 🔑

* 배경이 날아가는 것을 대비해서, 기본 배경 색상을 지정해놨다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 제대로 적용되는지 확인해주세요~

# 추가로 남길 메모가 있으신가요? 📝

## Attachment 📸

### 배경 이미지 나올 때
<img width="714" alt="스크린샷 2024-05-03 오후 2 03 43" src="https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/75800958/d3d06bfb-2868-4368-966c-8c1b84e755cc">

### 배경 이미지 안 나을 때
<img width="717" alt="스크린샷 2024-05-03 오후 2 03 54" src="https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/75800958/dbbb53f3-70df-48cc-ade5-bfb7a4320bd2">


* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
