### PR TITLE
화면의 너비가 360px 이하가 되면, 보여주는 이미지의 개수를 줄인다

### DIFF
--- a/src/hooks/useCheckScreenWidth.ts
+++ b/src/hooks/useCheckScreenWidth.ts
@@ -12,7 +12,9 @@ export default function useCheckScreenWidth(
     setWindowSize({
       width: window.innerWidth,
     });
-    if (window.innerWidth <= 550) {
+    if (window.innerWidth <= 360) {
+      setPerView(defaultPerview - 1.5);
+    } else if (window.innerWidth <= 550) {
       setPerView(defaultPerview - 1.3);
     } else {
       setPerView(defaultPerview - 0.3);

--- a/src/hooks/useCheckScreenWidth.ts
+++ b/src/hooks/useCheckScreenWidth.ts
@@ -13,7 +13,7 @@ export default function useCheckScreenWidth(
       width: window.innerWidth,
     });
     if (window.innerWidth <= 360) {
-      setPerView(defaultPerview - 1.5);
+      setPerView(defaultPerview - 1.6);
     } else if (window.innerWidth <= 550) {
       setPerView(defaultPerview - 1.3);
     } else {


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 화면의 너비가 360px 이하가 되면, 이미지가 겹쳐보였습니다. 
  * 메인 페이지 라인업
  * 타임테이블 라인업

# 어떻게 해결하셨나요? 🔑

* 화면의 너비가 360px 이하가 되면, 보여주는 이미지의 개수를 더 줄이도록 했습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

작은 화면을 가진 디바이스에서 아래 부분의 이미지가 겹치지 않도록 했습니다.
확인 부탁드립니다!

* 메인 페이지 라인업
* 타임테이블 라인업

# 추가로 남길 메모가 있으신가요? 📝

아래 부분은 고치지 않았습니다. 
360px 이하의 너비를 가진 폰을 쓰는 사람이 없을 것 같은데 어떻게 생각하시나요?

* 메인 페이지의  한 줄 외치기 키워드가 한 화면에 보여줄 수 있는 갯수를 초과해서 하나만 보여지는 현상
* 메인 페이지 랭킹 글씨 겹치는 현상

<img width="255" alt="스크린샷 2024-05-03 오후 2 38 22" src="https://github.com/INU-CapstoneDesign/INU-Festival-FE/assets/75800958/7dcb6476-60c9-4eb2-9fad-c130f969a40a">

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
