### PR TITLE
sentence를 불러올 때 토큰을 헤더에 추가한다

### DIFF
--- a/src/components/GuestBook/MessageContainer.tsx
+++ b/src/components/GuestBook/MessageContainer.tsx
@@ -77,7 +77,7 @@ export default function MessageContainer({ msg, name }: {msg: Message, name: str
       </Content>
       <User>
         <img src={`${emoji}.svg`} alt="이모지" />
-        <b>{`${studentId.slice(0, 6)}***`}</b>
+        <b>{studentId}</b>
       </User>
     </MessageBox>
   );

--- a/src/components/GuestBook/MessageContainer.tsx
+++ b/src/components/GuestBook/MessageContainer.tsx
@@ -77,7 +77,7 @@ export default function MessageContainer({ msg, name }: {msg: Message, name: str
       </Content>
       <User>
         <img src={`${emoji}.svg`} alt="이모지" />
-        <b>{studentId}</b>
+        <b>{`${studentId.slice(0, 6)}***`}</b>
       </User>
     </MessageBox>
   );

--- a/src/hooks/useFetchSentence.tsx
+++ b/src/hooks/useFetchSentence.tsx
@@ -9,5 +9,11 @@ type Sentences = {
 }
 
 export default function useFetchSentence() {
-  return useFetch<Sentences>(url);
+  const accessToken = localStorage.getItem('accessToken') || '';
+
+  return useFetch<Sentences>(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
 }


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 방명록을 불러올 때 백엔드에서 학번을 가려서 보내주고, 토큰을 확인해서 본인의 학번만 다 보여주기로 했습니다.

# 어떻게 해결하셨나요? 🔑

* get할 때 헤더에 토큰을 추가하고, 학번을 가리는 부분을 지웠습니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 로그인해서 본인이 적은 메세지는 오른쪽에 잘 출력되는지 봐주세요!

# 추가로 남길 메모가 있으신가요? 📝

* 혹시 본인의 학번도 뒤에는 가리는 것이 좋을까요??

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
