### PR TITLE
오늘 날짜에 해당하는 라인업을 보여줍니다. 만약 오늘에 해당하는 라인업이 없으면 기본 값으로 첫 째날을 보여줍니다.

### DIFF
--- a/src/components/TimeTable/FilterableTimeTable.tsx
+++ b/src/components/TimeTable/FilterableTimeTable.tsx
@@ -26,8 +26,11 @@ function selectDates(filteredPerforms: Perform[]) {
 }
 
 export default function FilterableTimeTable() {
+  const now = new Date();
+  const day = now.getDate();
+  const today = { 7: 'day1', 8: 'day2', 9: 'day3' };
   const [categories] = useState(['day1', 'day2', 'day3']);
-  const [filterCategory, setFilterCatergory] = useState<string>('day1');
+  const [filterCategory, setFilterCatergory] = useState(today[day] || 'day1');
 
   const { data } = useFetchPerforms();
   const filteredPerforms = data ? filterPerforms(data.performs, filterCategory) : [];


### PR DESCRIPTION
# 해결햐려는 문제가 무엇인가요? 🤔

* 날짜 상관없이 <1. 메인 페이지에서  ->  타임 테이블> / <2. 네비바 -> 타임 테이블> 둘 다 타임테이블은 첫 째날이 보여졌습니다.

# 어떻게 해결하셨나요? 🔑

* 오늘 날짜에 해당하는 라인업을 보여줍니다. 만약 오늘에 해당하는 라인업이 없으면 기본 값으로 첫째날을 보여줍니다.

# 어떤 부분을 리뷰 받았으면 좋겠나요? 🛠️

* 제대로 동작하는지 확인 부탁드립니다!

# 추가로 남길 메모가 있으신가요? 📝

*

## Attachment 📸

* 이번 MR의 Front 동작의 이해를 돕는 GIF 파일 첨부!
* 리뷰어의 이해를 돕기 위한 모듈/클래스 설계에 대한 Diagram 포함!
